### PR TITLE
fix: Fix is_ha locals condition: accept blank and null as true condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -40,5 +40,5 @@ variable "dnat_rules" {
 }
 
 locals {
-  is_ha = var.spoke_gw_object.ha_gw_size != null
+  is_ha = var.spoke_gw_object.ha_gw_size != null || var.spoke_gw_object.ha_gw_size != ""
 }


### PR DESCRIPTION
Relative to #4 .

The "HA" attributes from spoke_gw_object can be "" if the spoke gateway High Availability is not allowed.