### PR TITLE
Address spoke nonHA gw deployment - Logic change tested working fine in variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,5 +46,5 @@ variable "egress_nat" {
 }
 
 locals {
-  is_ha = var.spoke_gw_object.ha_gw_size != ""
+  is_ha = var.spoke_gw_object.ha_gw_size != null
 }


### PR DESCRIPTION
**Module > variables.tf  > line 49**

locals {
 **remove** is_ha = var.spoke_gw_object.ha_gw_size != null
**add**  is_ha = (var.spoke_gw_object.ha_gw_size == "") || (var.spoke_gw_object.ha_gw_size == null) ? "false" : "true"
 
}


The above change in condition logic works fine for both HA and nonHA gateway deployment.
(New deployment and any 're-apply'  (with/without changes))